### PR TITLE
fix: resolve recorder figure assets and scale images

### DIFF
--- a/packages/aimd-recorder/src/__tests__/recorder-render.test.ts
+++ b/packages/aimd-recorder/src/__tests__/recorder-render.test.ts
@@ -31,6 +31,16 @@ describe('AimdRecorder render stability', () => {
     expect(source).toMatch(/detailDisplay: props\.stepDetailDisplay/)
   })
 
+  it('routes markdown image nodes through resolveFile when a host resolver is provided', () => {
+    expect(source).toMatch(/function renderResolvedImage\(node: \{ properties\?: Record<string, unknown> \}\): VNode/)
+    expect(source).toMatch(/props\.resolveFile\(originalSrc\) \?\? originalSrc/)
+    expect(source).toMatch(/elementRenderers: props\.resolveFile/)
+    expect(source).toMatch(/img: node => renderResolvedImage\(node as \{ properties\?: Record<string, unknown> \}\)/)
+    expect(source).toMatch(/function renderInlineFigure\(node: AimdFigNode\): VNode/)
+    expect(source).toMatch(/const resolvedSrc = props\.resolveFile\?\.\(node\.src\) \?\? node\.src/)
+    expect(source).toMatch(/fig: node => renderInlineFigure\(node as AimdFigNode\)/)
+  })
+
   it('normalizes grouped step body nodes so grouped content does not re-render the step header inside its own body', () => {
     expect(source).toMatch(/function normalizeStepBodyNodes\(bodyNodes: VNodeChild\[] = \[]\): VNodeChild\[]/)
     expect(source).toMatch(/const groupedBody = bodyNodes\.find\(\(child\) => isGroupedStepBodyNode\(child\)\)/)

--- a/packages/aimd-recorder/src/components/AimdRecorder.vue
+++ b/packages/aimd-recorder/src/components/AimdRecorder.vue
@@ -3,6 +3,7 @@ import { computed, defineComponent, h, nextTick, onBeforeUnmount, reactive, ref,
 import type {
   AimdCheckNode,
   AimdClientAssignerField,
+  AimdFigNode,
   AimdQuizField,
   AimdQuizNode,
   AimdStepNode,
@@ -739,6 +740,66 @@ function renderInlineQuiz(node: AimdQuizNode): VNode {
   return applyFieldAdapter("quiz", fieldKey, node, localRecord.quiz[quizId], vnode)
 }
 
+function renderResolvedImage(node: { properties?: Record<string, unknown> }): VNode {
+  const properties = node.properties || {}
+  const originalSrc = typeof properties.src === "string" ? properties.src : ""
+  const resolvedSrc = originalSrc && props.resolveFile
+    ? props.resolveFile(originalSrc) ?? originalSrc
+    : originalSrc
+
+  return h("img", {
+    src: resolvedSrc,
+    alt: typeof properties.alt === "string" ? properties.alt : undefined,
+    title: typeof properties.title === "string" ? properties.title : undefined,
+    class: "aimd-image",
+    loading: "lazy",
+  })
+}
+
+function renderInlineFigure(node: AimdFigNode): VNode {
+  const fieldKey = `fig:${node.id}`
+
+  if (props.customRenderers?.fig) {
+    const custom = props.customRenderers.fig(node, {} as any, [])
+    if (custom) {
+      return custom as VNode
+    }
+  }
+
+  const resolvedSrc = props.resolveFile?.(node.src) ?? node.src
+  const captionChildren: VNodeChild[] = []
+  const figureLabel = resolvedLocale.value === "zh-CN" ? "图" : "Figure"
+
+  if (node.sequence !== undefined || node.title) {
+    const titleText = node.sequence !== undefined
+      ? `${figureLabel} ${node.sequence + 1}${node.title ? `. ${node.title}` : ""}`
+      : node.title
+    captionChildren.push(h("div", { class: "aimd-figure__title" }, titleText))
+  }
+
+  if (node.legend) {
+    captionChildren.push(h("div", { class: "aimd-figure__legend" }, node.legend))
+  }
+
+  return h("figure", {
+    class: "aimd-figure",
+    "data-aimd-type": "fig",
+    "data-aimd-fig-id": node.id,
+    "data-aimd-fig-src": resolvedSrc,
+    id: `fig-${node.id}`,
+  }, [
+    h("img", {
+      class: "aimd-figure__image",
+      src: resolvedSrc,
+      alt: node.title || node.id,
+      loading: "lazy",
+    }),
+    captionChildren.length > 0
+      ? h("figcaption", { class: "aimd-figure__caption" }, captionChildren)
+      : null,
+  ])
+}
+
 // ---------------------------------------------------------------------------
 // Rebuild pipeline
 // ---------------------------------------------------------------------------
@@ -758,12 +819,18 @@ async function rebuildInlineNodes(
       value: localRecord as Record<string, Record<string, unknown>>,
     },
     blockVarTypes: ["AiralogyMarkdown"],
+    elementRenderers: props.resolveFile
+      ? {
+          img: node => renderResolvedImage(node as { properties?: Record<string, unknown> }),
+        }
+      : undefined,
     aimdRenderers: {
       var: node => renderInlineVar(node as AimdVarNode),
       var_table: node => renderInlineVarTable(node as AimdVarTableNode),
       step: (node, _ctx, children) => renderInlineStep(node as AimdStepNode, children),
       check: node => renderInlineCheck(node as AimdCheckNode),
       quiz: node => renderInlineQuiz(node as AimdQuizNode),
+      fig: node => renderInlineFigure(node as AimdFigNode),
     },
   })
 

--- a/packages/aimd-recorder/src/styles/aimd.css
+++ b/packages/aimd-recorder/src/styles/aimd.css
@@ -369,6 +369,37 @@
   font-weight: 500;
 }
 
+/* Markdown / figure media should scale within the recorder document width. */
+.aimd-image,
+.aimd-figure__image {
+  display: block;
+  max-width: 100%;
+  width: auto;
+  height: auto;
+  margin: 0 auto;
+  object-fit: contain;
+}
+
+.aimd-figure {
+  display: grid;
+  gap: 10px;
+  max-width: 100%;
+  width: fit-content;
+  margin: 16px auto;
+}
+
+.aimd-figure__caption {
+  max-width: min(100%, 72ch);
+  margin: 0 auto;
+  color: #5b625f;
+  line-height: 1.6;
+}
+
+.aimd-figure__title {
+  font-weight: 600;
+  color: #24352c;
+}
+
 /* Editable state */
 .aimd-field--editable {
   cursor: text;


### PR DESCRIPTION
## Summary
- route recorder markdown images through the host-provided resolveFile hook
- apply the same asset resolution path to AIMD figure nodes
- add responsive recorder styles so rendered images stay within the document width

## Testing
- pnpm --dir aimd test:vitest -- aimd-recorder/src/__tests__/recorder-render.test.ts
