### PR TITLE
fix(editor): 收口全高布局并修正 Monaco worker 路由

### DIFF
--- a/docs/en/packages/aimd-editor/vue-editor.md
+++ b/docs/en/packages/aimd-editor/vue-editor.md
@@ -17,6 +17,8 @@ const content = ref("")
 </template>
 ```
 
+Set `:min-height="0"` to make the editor fill a parent container with an explicit height. Leave `minHeight` positive to keep the default fixed editor height behavior.
+
 ## Localization
 
 The Vue editor includes built-in `en-US` and `zh-CN` UI messages.

--- a/docs/zh/packages/aimd-editor/vue-editor.md
+++ b/docs/zh/packages/aimd-editor/vue-editor.md
@@ -17,6 +17,8 @@ const content = ref("")
 </template>
 ```
 
+如果要让编辑器填满一个已明确高度的父容器，可以设置 `:min-height="0"`。当 `minHeight` 为正数时，会保持现有的固定最小高度行为。
+
 ## 国际化
 
 Vue 编辑器内建 `en-US` 和 `zh-CN` 两套 UI 文案。

--- a/packages/aimd-editor/CHANGELOG.md
+++ b/packages/aimd-editor/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to `@airalogy/aimd-editor` will be documented in this file.
 
 ## [Unreleased]
+ 
+- Scoped full-height editor layout to `minHeight={0}` only, so embeds inside fixed-height parents no longer regress when using the default editor height.
+- Routed Monaco language-service workers using both `moduleId` and `label`, and initialized `MonacoEnvironment` before loading `monaco-editor`, so source/code editor requests no longer fall through to the generic `editor.worker`.
 
 ## [1.7.0] - 2026-03-26
 

--- a/packages/aimd-editor/README.md
+++ b/packages/aimd-editor/README.md
@@ -36,6 +36,8 @@ Use `messages` to override built-in copy per locale.
 
 For advanced embedding, the low-level `AimdWysiwygEditor` now accepts a custom Milkdown plugin chain, and `AimdFieldDialog` can be limited to a focused subset of AIMD field kinds with `allowedTypes`.
 
+Set `:min-height="0"` to make the editor fill a parent container with an explicit height. Leave `minHeight` positive to keep the default fixed editor height behavior.
+
 ## Documentation
 
 - EN: <https://airalogy.github.io/aimd/en/packages/aimd-editor>

--- a/packages/aimd-editor/README.zh-CN.md
+++ b/packages/aimd-editor/README.zh-CN.md
@@ -36,6 +36,8 @@ import { AimdEditor } from "@airalogy/aimd-editor"
 
 如果要做更底层的嵌入式集成，`AimdWysiwygEditor` 现在支持注入自定义 Milkdown plugin 链，`AimdFieldDialog` 也支持通过 `allowedTypes` 限定可插入的 AIMD 字段类型。
 
+如果希望编辑器填满一个已明确高度的父容器，可以设置 `:min-height="0"`。保留正数 `minHeight` 时，编辑器仍会维持默认的固定最小高度行为。
+
 ## 文档
 
 - EN: <https://airalogy.github.io/aimd/en/packages/aimd-editor>

--- a/packages/aimd-editor/src/css.d.ts
+++ b/packages/aimd-editor/src/css.d.ts
@@ -1,0 +1,9 @@
+declare module "*.css"
+
+declare module "*?worker" {
+  const WorkerFactory: {
+    new (): Worker
+  }
+
+  export default WorkerFactory
+}

--- a/packages/aimd-editor/src/vue/AimdEditor.vue
+++ b/packages/aimd-editor/src/vue/AimdEditor.vue
@@ -88,6 +88,9 @@ function toggleTheme() {
 
 const shouldMountSourceEditor = computed(() => props.keepInactiveEditorsMounted || editorMode.value === 'source')
 const shouldMountWysiwygEditor = computed(() => props.keepInactiveEditorsMounted || editorMode.value === 'wysiwyg')
+const isFullHeightMode = computed(() => props.minHeight === 0)
+const editorPanelStyle = computed(() => isFullHeightMode.value ? { height: '100%' } : { minHeight: props.minHeight + 'px' })
+const editorPaneStyle = computed(() => isFullHeightMode.value ? { height: '100%' } : undefined)
 
 // --- Computed toolbar items ---
 const localizedFieldTypes = computed(() => createAimdFieldTypes(resolvedMessages.value))
@@ -162,7 +165,7 @@ defineExpose({
 </script>
 
 <template>
-  <div class="aimd-editor">
+  <div class="aimd-editor" :class="{ 'aimd-editor--full-height': isFullHeightMode }">
     <!-- Unified toolbar: mode switch + markdown + aimd -->
     <AimdEditorToolbar
       v-if="showToolbar"
@@ -180,9 +183,9 @@ defineExpose({
     />
 
     <!-- Editor area -->
-      <div class="aimd-editor-panel" :style="{ minHeight: minHeight + 'px' }">
+      <div class="aimd-editor-panel" :style="editorPanelStyle">
         <!-- Source mode: Monaco -->
-      <div v-if="shouldMountSourceEditor" v-show="editorMode === 'source'">
+      <div v-if="shouldMountSourceEditor" v-show="editorMode === 'source'" class="aimd-editor-pane" :style="editorPaneStyle">
         <AimdSourceEditor
           ref="sourceEditorRef"
           :content="content"
@@ -198,7 +201,7 @@ defineExpose({
       </div>
 
       <!-- WYSIWYG mode: Milkdown -->
-      <div v-if="shouldMountWysiwygEditor" v-show="editorMode === 'wysiwyg'">
+      <div v-if="shouldMountWysiwygEditor" v-show="editorMode === 'wysiwyg'" class="aimd-editor-pane" :style="editorPaneStyle">
         <AimdWysiwygEditor
           ref="wysiwygEditorRef"
           :content="content"
@@ -235,6 +238,10 @@ defineExpose({
   border: 1px solid #e0e0e0;
   border-radius: 8px;
   overflow: hidden;
+}
+
+.aimd-editor--full-height {
+  height: 100%;
 }
 
 /* --- Unified toolbar --- */
@@ -374,8 +381,32 @@ defineExpose({
   overflow: hidden;
 }
 
+.aimd-editor-pane {
+  min-height: 0;
+}
+
+.aimd-editor--full-height .aimd-editor-panel {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.aimd-editor--full-height .aimd-editor-pane {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
 .aimd-editor-source-mode {
   overflow: hidden;
+}
+
+.aimd-editor--full-height .aimd-editor-source-mode,
+.aimd-editor--full-height .aimd-editor-wysiwyg-mode {
+  flex: 1;
+  min-height: 0;
 }
 
 .aimd-editor-container {

--- a/packages/aimd-editor/src/vue/AimdSourceEditor.vue
+++ b/packages/aimd-editor/src/vue/AimdSourceEditor.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted, onBeforeUnmount, watch } from 'vue'
 import type { AimdEditorMessages } from './locales'
+import { ensureMonacoEnvironment } from './monaco-environment'
 
 const props = defineProps<{
   content: string
@@ -241,6 +242,7 @@ function createEditor(monaco: any) {
 onMounted(async () => {
   try {
     loading.value = true
+    ensureMonacoEnvironment()
     const monaco = await import('monaco-editor')
     monacoModule = monaco
     registerAimdLanguage(monaco)

--- a/packages/aimd-editor/src/vue/AimdSourceEditor.vue
+++ b/packages/aimd-editor/src/vue/AimdSourceEditor.vue
@@ -325,7 +325,7 @@ defineExpose({
 </script>
 
 <template>
-  <div class="aimd-editor-source-mode" :style="{ height: minHeight + 'px' }">
+  <div class="aimd-editor-source-mode" :style="minHeight > 0 ? { height: minHeight + 'px' } : { height: '100%' }">
     <div v-if="loading" class="aimd-editor-loading">{{ resolvedMessages.common.loadingEditor }}</div>
     <div ref="editorContainer" class="aimd-editor-container" />
   </div>

--- a/packages/aimd-editor/src/vue/AimdWysiwygEditor.vue
+++ b/packages/aimd-editor/src/vue/AimdWysiwygEditor.vue
@@ -535,7 +535,7 @@ defineExpose({
 </script>
 
 <template>
-  <div class="aimd-editor-wysiwyg-mode" :style="{ height: minHeight + 'px', overflowY: 'auto' }">
+  <div class="aimd-editor-wysiwyg-mode" :style="minHeight > 0 ? { height: minHeight + 'px', overflowY: 'auto' } : { height: '100%', overflowY: 'auto' }">
     <MilkdownProvider>
       <MilkdownEditorInner
         :default-value="content"

--- a/packages/aimd-editor/src/vue/monaco-environment.ts
+++ b/packages/aimd-editor/src/vue/monaco-environment.ts
@@ -1,0 +1,84 @@
+import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker'
+import cssWorker from 'monaco-editor/esm/vs/language/css/css.worker?worker'
+import htmlWorker from 'monaco-editor/esm/vs/language/html/html.worker?worker'
+import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker'
+import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker'
+
+type MonacoEnvironmentShape = {
+  getWorker?: (moduleId: string, label: string) => Worker
+}
+
+function resolveWorkerKind(moduleId: string, label: string): 'json' | 'css' | 'html' | 'ts' | 'editor' {
+  const normalizedLabel = (label || '').toLowerCase()
+  const normalizedModuleId = (moduleId || '').toLowerCase()
+  const hint = `${normalizedModuleId} ${normalizedLabel}`
+
+  if (normalizedLabel === 'json' || hint.includes('/json/')) {
+    return 'json'
+  }
+
+  if (
+    normalizedLabel === 'css'
+    || normalizedLabel === 'scss'
+    || normalizedLabel === 'less'
+    || hint.includes('/css/')
+  ) {
+    return 'css'
+  }
+
+  if (
+    normalizedLabel === 'html'
+    || normalizedLabel === 'handlebars'
+    || normalizedLabel === 'razor'
+    || hint.includes('/html/')
+  ) {
+    return 'html'
+  }
+
+  if (
+    normalizedLabel === 'typescript'
+    || normalizedLabel === 'javascript'
+    || hint.includes('/typescript/')
+    || hint.includes('/javascript/')
+    || hint.includes('/tsworker')
+  ) {
+    return 'ts'
+  }
+
+  return 'editor'
+}
+
+export function ensureMonacoEnvironment() {
+  if (typeof globalThis === 'undefined') {
+    return
+  }
+
+  const existing = (globalThis as { MonacoEnvironment?: MonacoEnvironmentShape }).MonacoEnvironment
+  if (typeof existing?.getWorker === 'function') {
+    return
+  }
+
+  ;(globalThis as { MonacoEnvironment?: MonacoEnvironmentShape }).MonacoEnvironment = {
+    getWorker(moduleId: string, label: string) {
+      const workerKind = resolveWorkerKind(moduleId, label)
+
+      if (workerKind === 'json') {
+        return new jsonWorker()
+      }
+
+      if (workerKind === 'css') {
+        return new cssWorker()
+      }
+
+      if (workerKind === 'html') {
+        return new htmlWorker()
+      }
+
+      if (workerKind === 'ts') {
+        return new tsWorker()
+      }
+
+      return new editorWorker()
+    },
+  }
+}

--- a/packages/aimd-editor/src/vue/types.ts
+++ b/packages/aimd-editor/src/vue/types.ts
@@ -61,7 +61,7 @@ export interface AimdEditorProps {
   enableSlashMenu?: boolean
   /** Whether inactive source / WYSIWYG panes stay mounted in the DOM */
   keepInactiveEditorsMounted?: boolean
-  /** Minimum height of the editor area in px */
+  /** Minimum height of the editor area in px. Set to 0 to fill a parent with explicit height. */
   minHeight?: number
   /** Whether the editor is read-only */
   readonly?: boolean

--- a/packages/aimd-editor/tests/milkdown-aimd-plugin.test.mjs
+++ b/packages/aimd-editor/tests/milkdown-aimd-plugin.test.mjs
@@ -177,8 +177,19 @@ test('AimdEditor can unmount inactive editor panes for embedded recorder fields'
   assert.match(editorSource, /keepInactiveEditorsMounted: true/)
   assert.match(editorSource, /const shouldMountSourceEditor = computed\(\(\) => props\.keepInactiveEditorsMounted \|\| editorMode\.value === 'source'\)/)
   assert.match(editorSource, /const shouldMountWysiwygEditor = computed\(\(\) => props\.keepInactiveEditorsMounted \|\| editorMode\.value === 'wysiwyg'\)/)
-  assert.match(editorSource, /<div v-if="shouldMountSourceEditor" v-show="editorMode === 'source'">/)
-  assert.match(editorSource, /<div v-if="shouldMountWysiwygEditor" v-show="editorMode === 'wysiwyg'">/)
+  assert.match(editorSource, /<div v-if="shouldMountSourceEditor" v-show="editorMode === 'source'" class="aimd-editor-pane" :style="editorPaneStyle">/)
+  assert.match(editorSource, /<div v-if="shouldMountWysiwygEditor" v-show="editorMode === 'wysiwyg'" class="aimd-editor-pane" :style="editorPaneStyle">/)
+})
+
+test('AimdEditor gates full-height layout to minHeight zero mode', () => {
+  assert.match(typesSource, /Set to 0 to fill a parent with explicit height/)
+  assert.match(editorSource, /const isFullHeightMode = computed\(\(\) => props\.minHeight === 0\)/)
+  assert.match(editorSource, /const editorPanelStyle = computed\(\(\) => isFullHeightMode\.value \? \{ height: '100%' } : \{ minHeight: props\.minHeight \+ 'px' }\)/)
+  assert.match(editorSource, /const editorPaneStyle = computed\(\(\) => isFullHeightMode\.value \? \{ height: '100%' } : undefined\)/)
+  assert.match(editorSource, /<div class="aimd-editor" :class="\{ 'aimd-editor--full-height': isFullHeightMode \}">/)
+  assert.match(editorSource, /<div class="aimd-editor-panel" :style="editorPanelStyle">/)
+  assert.match(sourceEditorSource, /:style="minHeight > 0 \? \{ height: minHeight \+ 'px' } : \{ height: '100%' }"/)
+  assert.match(wysiwygSource, /:style="minHeight > 0 \? \{ height: minHeight \+ 'px', overflowY: 'auto' } : \{ height: '100%', overflowY: 'auto' }"/)
 })
 
 test('AimdEditorToolbar uses non-submit buttons for host safety', () => {

--- a/packages/aimd-recorder/src/monaco-code.ts
+++ b/packages/aimd-recorder/src/monaco-code.ts
@@ -23,6 +23,46 @@ const contributionLoaders: Record<string, () => Promise<unknown>> = {
 
 const loadedContributionPromises = new Map<string, Promise<void>>()
 
+function resolveWorkerKind(moduleId: string, label: string): 'json' | 'css' | 'html' | 'ts' | 'editor' {
+  const normalizedLabel = (label || '').toLowerCase()
+  const normalizedModuleId = (moduleId || '').toLowerCase()
+  const hint = `${normalizedModuleId} ${normalizedLabel}`
+
+  if (normalizedLabel === 'json' || hint.includes('/json/')) {
+    return 'json'
+  }
+
+  if (
+    normalizedLabel === 'css'
+    || normalizedLabel === 'scss'
+    || normalizedLabel === 'less'
+    || hint.includes('/css/')
+  ) {
+    return 'css'
+  }
+
+  if (
+    normalizedLabel === 'html'
+    || normalizedLabel === 'handlebars'
+    || normalizedLabel === 'razor'
+    || hint.includes('/html/')
+  ) {
+    return 'html'
+  }
+
+  if (
+    normalizedLabel === 'typescript'
+    || normalizedLabel === 'javascript'
+    || hint.includes('/typescript/')
+    || hint.includes('/javascript/')
+    || hint.includes('/tsworker')
+  ) {
+    return 'ts'
+  }
+
+  return 'editor'
+}
+
 export function ensureMonacoEnvironment() {
   if (typeof globalThis === 'undefined') {
     return
@@ -36,20 +76,22 @@ export function ensureMonacoEnvironment() {
   ;(globalThis as {
     MonacoEnvironment?: { getWorker: (moduleId: string, label: string) => Worker }
   }).MonacoEnvironment = {
-    getWorker(_: string, label: string) {
-      if (label === 'json') {
+    getWorker(moduleId: string, label: string) {
+      const workerKind = resolveWorkerKind(moduleId, label)
+
+      if (workerKind === 'json') {
         return new jsonWorker()
       }
 
-      if (label === 'css' || label === 'scss' || label === 'less') {
+      if (workerKind === 'css') {
         return new cssWorker()
       }
 
-      if (label === 'html' || label === 'handlebars' || label === 'razor') {
+      if (workerKind === 'html') {
         return new htmlWorker()
       }
 
-      if (label === 'typescript' || label === 'javascript') {
+      if (workerKind === 'ts') {
         return new tsWorker()
       }
 


### PR DESCRIPTION
## 概要

- 合并原 PR #8 与 PR #13，统一处理 `aimd-editor` 中同一处 `AimdSourceEditor` 相关改动
- 仅在 `minHeight === 0` 时启用全高布局，避免已有固定高度嵌入场景回归
- 在加载 `monaco-editor` 之前初始化 `MonacoEnvironment.getWorker()`
- 让 Monaco worker 路由同时参考 `moduleId` 和 `label`，避免语言请求误落到通用 `editor.worker`
- 为 `?worker` 导入补充 TypeScript 类型声明

## 为什么把两个 PR 合并

原 PR #8 和原 PR #13 都改到了 `packages/aimd-editor/src/vue/AimdSourceEditor.vue`，虽然逻辑上是正交的：

- PR #8 修的是 source editor 的高度策略
- PR #13 修的是 source editor 的 Monaco worker 初始化

但它们在代码审阅和 GitHub 合并层面会互相碰到同一个文件，分开维护会持续制造冲突和重复解释成本。把它们合并成一个 PR 之后，reviewer 只需要沿着同一条集成路径理解：

1. source editor 怎么决定高度
2. source editor 什么时候初始化 Monaco worker
3. recorder/editor 两边怎样共享正确的 worker 路由策略

这样更容易审，也更容易一次性验证完整行为。

## 问题 1：全高布局不应影响已有固定高度嵌入

之前的全高调整会把 source / wysiwyg 编辑器统一拉成 `height: 100%`。这对新引入的“全高嵌入模式”是对的，但会影响原本已经放在固定高度容器里的现有接入方。

这次改动把全高能力收口到显式约定：

- 当 `minHeight > 0` 时，继续按固定高度工作
- 只有当 `minHeight === 0` 时，才进入 `height: 100%` 的全高嵌入模式

这样保留了新的嵌入能力，同时避免对旧用法产生布局回归。

## 问题 2：Monaco 语言请求被错误路由到 `editor.worker`

source mode 和 recorder 里的代码编辑能力依赖 Monaco 的多 worker 机制。之前存在两个问题：

1. `aimd-editor` 在动态 `import('monaco-editor')` 之前，没有先安装 `MonacoEnvironment.getWorker()`
2. `aimd-recorder` 的 worker 选择逻辑只看 `label`

在某些打包路径下，Monaco 用来判断语言 worker 的有效线索只出现在 `moduleId` 中。如果只看 `label`，JSON/CSS/HTML/TS 的语言服务请求可能会回退到通用 `editor.worker`，然后出现类似下面的错误：

- `doValidation`
- `findDocumentColors`
- `findDocumentSymbols`
- `getFoldingRanges`

这些请求应该进入对应的语言 worker，而不是通用 worker。

## 这次怎么修

### `aimd-editor`

- 新增 `monaco-environment.ts`
- 在 `AimdSourceEditor` 挂载时，先调用 `ensureMonacoEnvironment()`
- 然后再动态加载 `monaco-editor`

这样 Monaco 初始化阶段就能拿到正确的 worker 工厂映射。

### `aimd-recorder`

- 保留现有 worker 工厂
- 但 worker 分类不再只看 `label`
- 改为同时使用 `moduleId + label` 判断是 `json` / `css` / `html` / `ts` / `editor`

这样可以覆盖更多 bundler 输出路径，减少语言请求误路由。

## 兼容性说明

这不是功能层面的行为扩张，而是两处兼容性修正：

- 布局上，限制全高模式只在显式 `minHeight === 0` 时开启
- 编辑器能力上，保证 Monaco 语言服务请求进入正确 worker

因此它的目标是：

- 保住已有嵌入方的稳定布局
- 恢复 source/code editor 的语言服务稳定性

## 验证

已通过：

- `pnpm --dir packages/aimd-editor test`
- `pnpm --dir packages/aimd-editor type-check`
- `pnpm --dir packages/aimd-editor build`

已确认本 PR 变更不引入新的 `aimd-recorder` 构建问题，但当前最新 `upstream/main` 上仍存在与本 PR 无关的既有问题：

- `pnpm --dir packages/aimd-recorder type-check`
  `recorderMilkdownPlugin.ts` 中若干 `@milkdown/kit/*` 子路径在当前主干无法解析
- `pnpm --dir packages/aimd-recorder build`
  同样卡在 `@milkdown/kit/prose/dropcursor` 解析失败
