### PR TITLE
fix(recorder): hide untimed step timers and prefer step titles

### DIFF
--- a/packages/aimd-recorder/CHANGELOG.md
+++ b/packages/aimd-recorder/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to `@airalogy/aimd-recorder` will be documented in this file.
 
 ## [Unreleased]
+- Hid built-in step timer UI for steps that do not declare timing metadata, so plain and checkbox-enabled steps stay compact unless `duration` or `timer` is configured.
+- Updated recorder step headers to prefer human-readable AIMD step `title` values while keeping the raw step id as the data key.
 
 ## [1.12.0] - 2026-03-26
 

--- a/packages/aimd-recorder/src/__tests__/step-field.test.ts
+++ b/packages/aimd-recorder/src/__tests__/step-field.test.ts
@@ -68,6 +68,26 @@ describe('AimdStepField', () => {
     expect(wrapper.find('input[type="checkbox"]').exists()).toBe(true)
   })
 
+  it('hides timer UI entirely for an untimed step', () => {
+    const state = reactive(createEmptyStepRecordItem())
+    const wrapper = mount(AimdStepField, {
+      props: {
+        ...createBaseProps({
+          estimated_duration_ms: undefined,
+          timer_mode: undefined,
+          check: false,
+        }),
+        state,
+      },
+    })
+
+    expect(wrapper.text()).not.toContain('ETA')
+    expect(wrapper.text()).not.toContain('Timer')
+    expect(wrapper.find('.aimd-step-field__toggle--timer').exists()).toBe(false)
+    expect(wrapper.find('.aimd-step-field__detail--timer').exists()).toBe(false)
+    expect(wrapper.find('.aimd-step-timer__pill--actual').exists()).toBe(false)
+  })
+
   it('shows the annotation detail when a note already exists in auto mode', () => {
     const state = reactive({
       ...createEmptyStepRecordItem(),
@@ -266,5 +286,37 @@ describe('AimdStepField', () => {
     })
 
     expect(wrapper.find('.aimd-check-field__key').text()).toBe('verify_tube_label')
+  })
+
+  it('prefers the step title in the visible header label', () => {
+    const state = reactive(createEmptyStepRecordItem())
+    const wrapper = mount(AimdStepField, {
+      props: {
+        ...createBaseProps({
+          id: 'verify_tube_label',
+          title: 'Verify Tube Label',
+        }),
+        state,
+      },
+    })
+
+    expect(wrapper.find('.aimd-field__name').text()).toBe('Verify Tube Label')
+    expect(wrapper.text()).toContain('Verify Tube Label')
+    expect(wrapper.find('.aimd-field__name').text()).not.toBe('verify_tube_label')
+  })
+
+  it('falls back to the step id when no title is provided', () => {
+    const state = reactive(createEmptyStepRecordItem())
+    const wrapper = mount(AimdStepField, {
+      props: {
+        ...createBaseProps({
+          id: 'verify_tube_label',
+          title: undefined,
+        }),
+        state,
+      },
+    })
+
+    expect(wrapper.find('.aimd-field__name').text()).toBe('verify_tube_label')
   })
 })

--- a/packages/aimd-recorder/src/components/AimdStepCheckField.vue
+++ b/packages/aimd-recorder/src/components/AimdStepCheckField.vue
@@ -8,6 +8,7 @@ import {
   formatStepDuration,
   getStepElapsedMs,
   getStepRemainingMs,
+  hasStepTimerConfig,
   hasRecordedStepDuration,
   isStepTimerWarning,
   isStepTimerRunning,
@@ -67,18 +68,24 @@ export const AimdStepField = defineComponent({
     })
 
     const alwaysShowDetails = computed(() => props.detailDisplay === "always")
+    const stepDisplayLabel = computed(() => props.node.title?.trim() || props.node.id)
+    const timerAvailable = computed(() => hasStepTimerConfig(props.node))
     const actualElapsedMs = computed(() => getStepElapsedMs(props.state, nowMs.value))
     const actualDurationLabel = computed(() => formatStepDuration(actualElapsedMs.value, props.locale))
     const estimatedDurationLabel = computed(() => (
-      typeof props.node.estimated_duration_ms === "number"
+      timerAvailable.value && typeof props.node.estimated_duration_ms === "number"
         ? formatStepDuration(props.node.estimated_duration_ms, props.locale)
         : ""
     ))
-    const timerMode = computed<AimdStepTimerMode>(() => resolveStepTimerMode(props.node))
+    const timerMode = computed<AimdStepTimerMode | null>(() => resolveStepTimerMode(props.node))
     const timerRunning = computed(() => isStepTimerRunning(props.state))
     const hasRecordedDuration = computed(() => hasRecordedStepDuration(props.state))
     const hasAnnotation = computed(() => Boolean(props.state.annotation?.trim()))
-    const remainingMs = computed(() => getStepRemainingMs(props.state, props.node.estimated_duration_ms, nowMs.value))
+    const remainingMs = computed(() => (
+      timerAvailable.value
+        ? getStepRemainingMs(props.state, props.node.estimated_duration_ms, nowMs.value)
+        : undefined
+    ))
     const countdownEnabled = computed(() => timerMode.value === "countdown" || timerMode.value === "both")
     const showElapsedDetail = computed(() => timerMode.value === "elapsed" || timerMode.value === "both")
     const countdownWarning = computed(() => (
@@ -115,13 +122,19 @@ export const AimdStepField = defineComponent({
       || annotationExpanded.value
     ))
     const showTimerDetails = computed(() => (
-      alwaysShowDetails.value
-      || autoShowTimerDetails.value
-      || timerRunning.value
-      || hasRecordedDuration.value
-      || timerExpanded.value
+      timerAvailable.value && (
+        alwaysShowDetails.value
+        || autoShowTimerDetails.value
+        || timerRunning.value
+        || hasRecordedDuration.value
+        || timerExpanded.value
+      )
     ))
-    const showTimerSummary = computed(() => !showTimerDetails.value && (timerRunning.value || hasRecordedDuration.value))
+    const showTimerSummary = computed(() => (
+      timerAvailable.value
+      && !showTimerDetails.value
+      && (timerRunning.value || hasRecordedDuration.value)
+    ))
     const showDetailRow = computed(() => showAnnotationEditor.value || showTimerDetails.value)
 
     function clearPendingFocusOutCheck() {
@@ -167,6 +180,9 @@ export const AimdStepField = defineComponent({
     }
 
     function openTimerDetail() {
+      if (!timerAvailable.value) {
+        return
+      }
       timerExpanded.value = true
       emit("timer-start", { id: props.node.id })
     }
@@ -293,7 +309,7 @@ export const AimdStepField = defineComponent({
             : null,
           h("span", { class: "aimd-field__scope" }, getAimdRecorderScopeLabel("step", props.messages)),
           h("span", { class: "aimd-rec-inline__step-num" }, stepNumber),
-          h("span", { class: "aimd-field__name" }, id),
+          h("span", { class: "aimd-field__name" }, stepDisplayLabel.value),
         ]),
       )
 
@@ -330,7 +346,7 @@ export const AimdStepField = defineComponent({
         )
       }
 
-      if (!disabled && !showTimerDetails.value) {
+      if (!disabled && timerAvailable.value && !showTimerDetails.value) {
         headerActionChildren.push(
           h("button", {
             type: "button",

--- a/packages/aimd-recorder/src/composables/__tests__/useStepTimers.test.ts
+++ b/packages/aimd-recorder/src/composables/__tests__/useStepTimers.test.ts
@@ -6,6 +6,7 @@ import {
   getProtocolEstimatedDurationMs,
   getStepElapsedMs,
   getStepRemainingMs,
+  hasStepTimerConfig,
   isStepTimerWarning,
   pauseStepTimer,
   resetStepTimer,
@@ -37,9 +38,14 @@ describe('useStepTimers', () => {
   })
 
   it('resolves countdown modes only when an estimate exists', () => {
+    expect(hasStepTimerConfig({ estimated_duration_ms: 30_000 })).toBe(true)
+    expect(hasStepTimerConfig({ timer_mode: 'elapsed' })).toBe(true)
+    expect(hasStepTimerConfig({})).toBe(false)
+
     expect(resolveStepTimerMode({ timer_mode: 'countdown', estimated_duration_ms: 30_000 })).toBe('countdown')
     expect(resolveStepTimerMode({ timer_mode: 'both', estimated_duration_ms: 30_000 })).toBe('both')
     expect(resolveStepTimerMode({ timer_mode: 'countdown' })).toBe('elapsed')
+    expect(resolveStepTimerMode({})).toBe(null)
   })
 
   it('computes remaining time and warning thresholds for countdown timers', () => {

--- a/packages/aimd-recorder/src/composables/useStepTimers.ts
+++ b/packages/aimd-recorder/src/composables/useStepTimers.ts
@@ -130,9 +130,24 @@ export function formatStepDuration(ms: number, locale: string | undefined): stri
   return zh ? parts.join("") : parts.join(" ")
 }
 
+export function hasStepTimerConfig(
+  step: Pick<AimdStepField, "timer_mode" | "estimated_duration_ms">,
+): boolean {
+  const estimate = normalizeFiniteNumber(step.estimated_duration_ms, null)
+  if (estimate != null && estimate > 0) {
+    return true
+  }
+
+  return step.timer_mode != null
+}
+
 export function resolveStepTimerMode(
   step: Pick<AimdStepField, "timer_mode" | "estimated_duration_ms">,
-): AimdStepTimerMode {
+): AimdStepTimerMode | null {
+  if (!hasStepTimerConfig(step)) {
+    return null
+  }
+
   const configuredMode = step.timer_mode ?? "elapsed"
   const estimate = normalizeFiniteNumber(step.estimated_duration_ms, null)
 


### PR DESCRIPTION
## Summary
- hide step timer affordances unless the step explicitly has timer configuration
- prefer `step.title` over raw step id in the recorder card header
- add recorder tests for untimed steps and title-first rendering

## Problem
After timer support was added to step cards, the base step container became too timer-centric. Plain steps such as `{{step|sample_preparation}} ...` still rendered timer-related UI even though no timer behavior was configured. Step cards also remained hard to scan because the header displayed only the raw id, even when a human-readable title was available.

## Fix
This change keeps the timer feature for timed steps, but makes it opt-in at the UI level:
- untimed steps no longer show ETA pills, timer toggles, timer detail rows, or timer summary pills
- timed steps continue to support elapsed, countdown, and both modes
- recorder step headers now prefer `node.title?.trim() || node.id`

## Validation
Passed on the rebased branch:
- `pnpm --dir packages/aimd-recorder exec vitest run src/__tests__/step-field.test.ts src/composables/__tests__/useStepTimers.test.ts`

Current latest `upstream/main` still has an unrelated existing recorder type-check issue:
- `pnpm --dir packages/aimd-recorder type-check`
  fails in `src/components/recorderMilkdownPlugin.ts` because several `@milkdown/kit/*` subpath imports cannot be resolved

## Notes
This PR has been rebased onto the latest `upstream/main` and reduced to the effective recorder step/timer changes only, so the previous package-version and changelog conflicts are removed.
